### PR TITLE
Migrate to selenium.cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 [![Build Status](https://travis-ci.org/bwilczek/webdriver_pump.svg?branch=master)](https://travis-ci.org/bwilczek/webdriver_pump)
 
-This shard is a Page Object Model lib, built on top of [selenium-webdriver-crystal](https://github.com/ysbaddaden/selenium-webdriver-crystal).
-It's a crystal port of ruby's [watir_pump](https://github.com/bwilczek/watir_pump).
+This shard is a Page Object Model lib, built on top of [selenium.cr](https://github.com/matthewmcgarvey/selenium.cr).
+It's a crystal port of ruby's [watir_pump](https://github.com/bwilczek/watir_pump). Heavily inspired by [SitePrism](https://github.com/site-prism/site_prism).
+
+## WARNING
+
+The shard is being migrated from [selenium-webdriver-crystal](https://github.com/ysbaddaden/selenium-webdriver-crystal) to
+[selenium.cr](https://github.com/matthewmcgarvey/selenium.cr). At the moment locating elements by `id` or `name` is NOT SUPPORTED.
+Please use `xpath` or `css` until the missing location stratagies are implemented.
 
 ## Installation
 
@@ -32,7 +38,7 @@ end
 # use it in specs, for example:
 # where `session` is an instance of Selenium::Session
 describe "Page without components" do
-  it "operates on Selenium::WebElements" do
+  it "operates on Selenium::Elements" do
     GreeterPage.new(session).open do |p|
       p.header.should eq "Greeter app"
       p.fill_name "Crystal"
@@ -115,7 +121,7 @@ describe "Page's URL" do
   it "navigates to given URL" do
     GitHubUserPage.new(session).open do |page|
       page.class.should eq GitHubUserPage
-      page.user_nickname.class.should eq Selenium::WebElement
+      page.user_nickname.class.should eq Selenium::Element
       page.user_nickname.text.should eq "bwilczek"
     end
   end
@@ -174,7 +180,7 @@ Usually invoked implicitly by the `element(s)` macro.
 Accepts two parameters:
 
 * `@session : Selenium::Session`
-* `@root : Selenium::WebElement`
+* `@root : Selenium::Element`
 
 Example of explicit usage:
 
@@ -203,7 +209,7 @@ Reference to associated `Selenium::Session` instance.
 
 #### `#root`
 
-Mounting point of current component in the DOM tree. Type: `Selenium::WebElement`.
+Mounting point of current component in the DOM tree. Type: `Selenium::Element`.
 
 For `Pages` it points to `//body`.
 
@@ -225,7 +231,7 @@ WebdriverPump::Wait.interval = 0.5  # default = 0.2
 
 #### `element` macro
 
-A DSL macro to declare `WebElement`s located inside given component.
+A DSL macro to declare `Element`s located inside given component.
 
 ```crystal
 class MyPage < WebdriverPump::Page
@@ -235,21 +241,21 @@ class MyPage < WebdriverPump::Page
   # element :name : Symbol, params : NamedTuple
 
   # examples
-  # locate and return Selenium::WebElement
+  # locate and return Selenium::Element
   element :title1, { locator: {xpath: ".//div[@role='title']"} }
   # equivalent of:
   def title1
     root.find_element(:xpath, ".//div[@role='title']")
   end
 
-  # locate Selenium::WebElement and perform action (invoke method) on it at once
+  # locate Selenium::Element and perform action (invoke method) on it at once
   element :title2, { locator: {xpath: ".//div[@role='title']"}, action: :text }
   # equivalent of:
   def title2
     root.find_element(:xpath, ".//div[@role='title']").text
   end
 
-  # locate Selenium::WebElement and use it as a mounting point for another component
+  # locate Selenium::Element and use it as a mounting point for another component
   element :title3, { locator: {xpath: ".//div[@class='user_details']"}, class: UserDetails }
   # equivalent of:
   def title3
@@ -261,22 +267,22 @@ end
 
 ##### locator
 
-Required parameter. Locator of the `WebElement` in the DOM tree. Allowed formats are:
+Required parameter. Locator of the `Element` in the DOM tree. Allowed formats are:
 
 * 1 element `NamedTuple` with key in (`:id`, `:name`, `:tag_name`, `:class_name`, `:css`, `:link_text`, `:partial_link_text`, `:xpath`), and a respective value.
-* a `Proc` returning `WebElement`, e.g. `-> { root.find_element(:id, "user") }`, `-> { some_wrapper_element.find_element(:id, "user") }`
+* a `Proc` returning `Element`, e.g. `-> { root.find_element(:id, "user") }`, `-> { some_wrapper_element.find_element(:id, "user") }`
 
 ##### action
 
-`Symbol`, name of `WebElement`s method to be executed.
+`Symbol`, name of `Element`s method to be executed.
 
 ##### class
 
-`Component` class. If provided the `WebElement` located using `locator` will be the mounting point for the component of given class.
+`Component` class. If provided the `Element` located using `locator` will be the mounting point for the component of given class.
 
 #### `elements` macro
 
-A DSL macro to declare a collection of `WebElement`s inside given component.
+A DSL macro to declare a collection of `Element`s inside given component.
 
 ```crystal
 class CollectionIndexedByName(T) < WebdriverPump::ComponentCollection(T)
@@ -302,8 +308,8 @@ class OrderPage < WebdriverPump::Page
 end
 
 OrderPage.new(session).open do |page|
-  page.raw_order_items.class.should eq Array(Selenium::WebElement)
-  page.raw_order_items[0].class.should eq Selenium::WebElement
+  page.raw_order_items.class.should eq Array(Selenium::Element)
+  page.raw_order_items[0].class.should eq Selenium::Element
 
   page.order_items.class.should eq CollectionIndexedByName(OrderItem)
   page.order_items["Rubber hammer, 2kg"].should eq OrderItem
@@ -312,7 +318,7 @@ end
 
 ##### locator
 
-Required parameter. Same rules as for `element` macro, but returns `Array(WebElement)`.
+Required parameter. Same rules as for `element` macro, but returns `Array(Element)`.
 
 ##### class
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,14 +1,13 @@
 name: webdriver_pump
-version: 0.3.0
+version: 0.4.0
 
 authors:
   - Bartek Wilczek <bwilczek@gmail.com>
 
 dependencies:
   selenium:
-    github: ysbaddaden/selenium-webdriver-crystal
-    branch: master
+    github: matthewmcgarvey/selenium.cr
 
-crystal: 0.34.0
+crystal: 1.0.0
 
 license: MIT

--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -7,20 +7,21 @@ session = WebdriverSessionHelper.session
 class FormPage < Page
   url "#{WebdriverSessionHelper.base_url}/form.html"
 
-  form_element :name, {class: TextField, locator: {id: "name"}}
-  form_element :description, {class: TextArea, locator: {id: "description"}}
+  form_element :name, {class: TextField, locator: {css: "#name"}}
+  form_element :description, {class: TextArea, locator: {css: "#description"}}
 
-  form_element :gender, {class: RadioGroup, locator: {name: "gender"}}
-  form_element :predicate, {class: RadioGroup, locator: {name: "predicate"}}
+  form_element :gender, {class: RadioGroup, locator: {css: "[name=gender]"}}
+  form_element :predicate, {class: RadioGroup, locator: {css: "[name=predicate]"}}
 
-  form_element :hobbies, {class: CheckboxGroup, locator: {name: "hobbies[]"}}
-  form_element :continents, {class: CheckboxGroup, locator: {name: "continents[]"}}
+  # TODO: replace with name: hobbies[] as soon as it's added to selenium.cr
+  form_element :hobbies, {class: CheckboxGroup, locator: {xpath: ".//input[@name='hobbies[]']"}}
+  form_element :continents, {class: CheckboxGroup, locator: {xpath: ".//input[@name='continents[]']"}}
 
-  form_element :confirmation, {class: Checkbox, locator: {name: "confirmation"}}
+  form_element :confirmation, {class: Checkbox, locator: {css: "[name=confirmation]"}}
 
-  form_element :car, {class: SelectList, locator: {name: "car"}}
+  form_element :car, {class: SelectList, locator: {css: "[name=car]"}}
 
-  form_element :ingredients, {class: MultiSelectList, locator: {name: "ingredients[]"}}
+  form_element :ingredients, {class: MultiSelectList, locator: {xpath: ".//select[@name='ingredients[]']"}}
 
   fill_form :submit_data, {submit: :generate, fields: [:name, :description, :gender, :predicate]}
   form_data :read_data, {fields: [:name, :description, :gender, :predicate]}
@@ -28,15 +29,15 @@ class FormPage < Page
   fill_form :submit_for_summary, {submit: :generate, fields: [:name, :gender, :ingredients]}
   form_data :read_summary, {fields: [:summary_name, :summary_gender, :summary_ingredients]}
 
-  element :summary_name, {locator: {id: "res_name"}, action: :text}
-  element :summary_gender, {locator: {id: "res_gender"}, action: :text}
+  element :summary_name, {locator: {css: "#res_name"}, action: :text}
+  element :summary_gender, {locator: {css: "#res_gender"}, action: :text}
 
   def summary_ingredients
-    root.find_elements(:xpath, ".//ul[@id='res_ingredients']/li").map { |i| i.text }
+    root.find_child_elements(:xpath, ".//ul[@id='res_ingredients']/li").map { |i| i.text }
   end
 
   def generate
-    root.find_element(:id, "generate").click
+    root.find_child_element(:css, "#generate").click
   end
 end
 

--- a/spec/locate_components_spec.cr
+++ b/spec/locate_components_spec.cr
@@ -17,11 +17,11 @@ class ToDoListsPageForComponentLocators < WebdriverPump::Page
 
   element :todo_list_one, {
     class:   ToDoListForComponentLocators,
-    locator: {id: "todos_home"},
+    locator: {css: "#todos_home"},
   }
   element :todo_list_two, {
     class:   ToDoListForComponentLocators,
-    locator: ->{ root.find_element(:id, "todos_work") },
+    locator: ->{ root.find_child_element(:css, "#todos_work") },
   }
   elements :todo_lists, {
     class:   ToDoListForComponentLocators,
@@ -29,11 +29,11 @@ class ToDoListsPageForComponentLocators < WebdriverPump::Page
   }
   elements :todo_lists_lambda, {
     class:   ToDoListForComponentLocators,
-    locator: ->{ root.find_elements(:xpath, ".//div[@role='todo_list']") },
+    locator: ->{ root.find_child_elements(:xpath, ".//div[@role='todo_list']") },
   }
   element :todo_list_info, {
     class:   ToDoListForComponentLocators,
-    locator: {id: "todos_home"},
+    locator: {css: "#todos_home"},
     action:  :info,
   }
 end

--- a/spec/locate_elements_spec.cr
+++ b/spec/locate_elements_spec.cr
@@ -10,7 +10,7 @@ class ToDoListPageForElementLocators < WebdriverPump::Page
   element :title, {locator: {xpath: "//div[@role='title']"}}
   element :fill_item, {locator: {xpath: "//input[@role='new_item']"}}
   elements :items, {locator: {xpath: "//span[@role='name']"}}
-  elements :items_lambda, {locator: ->{ root.find_elements(:xpath, "//span[@role='name']") }}
+  elements :items_lambda, {locator: ->{ root.find_child_elements(:xpath, "//span[@role='name']") }}
 end
 
 ##############################################
@@ -19,28 +19,28 @@ describe WebdriverPump do
   it "single element with hash locator" do
     ToDoListPageForElementLocators.new(session).open do |p|
       p.title.displayed?.should be_true
-      p.title.class.should eq Selenium::WebElement
+      p.title.class.should eq Selenium::Element
     end
   end
 
   it "single element with lambda locator" do
     ToDoListPageForElementLocators.new(session).open do |p|
       p.fill_item.displayed?.should be_true
-      p.fill_item.class.should eq Selenium::WebElement
+      p.fill_item.class.should eq Selenium::Element
     end
   end
 
   it "multiple elements with hash locator" do
     ToDoListPageForElementLocators.new(session).open do |p|
       p.items.first.displayed?.should be_true
-      p.items.class.should eq Array(Selenium::WebElement)
+      p.items.class.should eq Array(Selenium::Element)
     end
   end
 
   it "multiple elements with lambda locator" do
     ToDoListPageForElementLocators.new(session).open do |p|
       p.items_lambda.first.displayed?.should be_true
-      p.items_lambda.class.should eq Array(Selenium::WebElement)
+      p.items_lambda.class.should eq Array(Selenium::Element)
     end
   end
 end

--- a/spec/nest_components_spec.cr
+++ b/spec/nest_components_spec.cr
@@ -48,7 +48,7 @@ class ToDoListsForNesting < WebdriverPump::Component
   }
   elements :raw_items, {
     locator:          {xpath: ".//li//span"},
-    collection_class: CollectionForShortElements(Selenium::WebElement),
+    collection_class: CollectionForShortElements(Selenium::Element),
   }
 
   def add(item)

--- a/spec/parametrized_url_spec.cr
+++ b/spec/parametrized_url_spec.cr
@@ -11,7 +11,7 @@ describe WebdriverPump do
     params = {user: "bwilczek", repo: "watir_pump_tutorial"}
     query = {name: "Bob", surname: "Smith"}
     ParametrizedPage.new(session).open(params: params, query: query) do |p|
-      session.url.should eq "https://bwilczek.github.io/watir_pump_tutorial/query.html?name=Bob&surname=Smith"
+      session.current_url.should eq "https://bwilczek.github.io/watir_pump_tutorial/query.html?name=Bob&surname=Smith"
     end
   end
 end

--- a/spec/support/webdriver_session_helper.cr
+++ b/spec/support/webdriver_session_helper.cr
@@ -1,4 +1,4 @@
-require "selenium/webdriver"
+require "selenium"
 
 class WebdriverSessionHelper
   @@session : Selenium::Session | Nil
@@ -9,17 +9,19 @@ class WebdriverSessionHelper
 
   def self.session
     @@session ||= begin
-      chromedriver = Process.new("chromedriver", args: {"--port=4444", "--url-base=/wd/hub"})
-      sleep 1
-      capabilities = {
-        browserName: "chrome",
-        platform:    "ANY",
-      }
-      driver = Selenium::Webdriver.new
-      session = Selenium::Session.new(driver, capabilities)
+      chrome_options = Selenium::Chrome::Capabilities::ChromeOptions.new
+      chrome_options.args = ["no-sandbox", "disable-gpu"]
+
+      capabilities = Selenium::Chrome::Capabilities.new
+      capabilities.chrome_options = chrome_options
+
+      chromedriver_path = `which chromedriver`.chomp
+
+      driver = Selenium::Driver.for(:chrome, service: Selenium::Service.chrome(driver_path: chromedriver_path))
+      session = driver.create_session(capabilities)
 
       Spec.after_suite do
-        session.stop
+        driver.stop
       end
       session
     end

--- a/src/webdriver_pump.cr
+++ b/src/webdriver_pump.cr
@@ -1,5 +1,5 @@
 module WebdriverPump
-  VERSION = "0.2.2"
+  VERSION = "0.4.0"
 end
 
 require "./webdriver_pump/locator"

--- a/src/webdriver_pump/component.cr
+++ b/src/webdriver_pump/component.cr
@@ -85,7 +85,7 @@ module WebdriverPump
       end
     end
 
-    def initialize(@session : Selenium::Session, @root : Selenium::WebElement)
+    def initialize(@session : Selenium::Session, @root : Selenium::Element)
     end
 
     def locate_element(locator : ElementLocator)
@@ -94,7 +94,7 @@ module WebdriverPump
       else # locator.is_a?(NamedTuple)
         by = locator.keys.first
         selector = locator.values.first
-        return @root.find_element(by, selector)
+        @root.find_child_element(by, selector)
       end
     end
 
@@ -104,7 +104,7 @@ module WebdriverPump
       else # locator.is_a?(NamedTuple)
         by = locator.keys.first
         selector = locator.values.first
-        return @root.find_elements(by, selector)
+        return @root.find_child_elements(by, selector)
       end
     end
 

--- a/src/webdriver_pump/elements/checkbox_group.cr
+++ b/src/webdriver_pump/elements/checkbox_group.cr
@@ -5,10 +5,10 @@ module WebdriverPump
       @elements.each do |el|
         next unless el.selected?
         begin
-          label = el.find_element(:xpath, "./parent::label")
+          label = el.find_child_element(:xpath, "./parent::label")
         rescue
           id = el.attribute("id")
-          label = el.find_element(:xpath, "//label[@for='#{id}']")
+          label = el.find_child_element(:xpath, "//label[@for='#{id}']")
         end
         ret << label.text
       end
@@ -18,10 +18,10 @@ module WebdriverPump
     def value=(val)
       @elements.each do |el|
         begin
-          label = el.find_element(:xpath, "./parent::label")
+          label = el.find_child_element(:xpath, "./parent::label")
         rescue
           id = el.attribute("id")
-          label = el.find_element(:xpath, "//label[@for='#{id}']")
+          label = el.find_child_element(:xpath, "//label[@for='#{id}']")
         end
         label.click if el.selected?
         label.click if val.includes?(label.text)

--- a/src/webdriver_pump/elements/multi_select_list.cr
+++ b/src/webdriver_pump/elements/multi_select_list.cr
@@ -2,14 +2,14 @@ module WebdriverPump
   class MultiSelectList < SimpleFormElement
     def value
       ret = Array(String).new
-      @element.find_elements(:xpath, ".//option").each do |option|
+      @element.find_child_elements(:xpath, ".//option").each do |option|
         ret << option.text if option.selected?
       end
       ret
     end
 
     def value=(val)
-      @element.find_elements(:xpath, ".//option").each do |option|
+      @element.find_child_elements(:xpath, ".//option").each do |option|
         option.click if option.selected?
         if val.includes?(option.text)
           option.click

--- a/src/webdriver_pump/elements/radio_group.cr
+++ b/src/webdriver_pump/elements/radio_group.cr
@@ -4,10 +4,10 @@ module WebdriverPump
       @elements.each do |el|
         next unless el.selected?
         begin
-          label = el.find_element(:xpath, "./parent::label")
+          label = el.find_child_element(:xpath, "./parent::label")
         rescue
           id = el.attribute("id")
-          label = el.find_element(:xpath, "//label[@for='#{id}']")
+          label = el.find_child_element(:xpath, "//label[@for='#{id}']")
         end
         return label.text
       end
@@ -16,10 +16,10 @@ module WebdriverPump
     def value=(val)
       @elements.each do |el|
         begin
-          label = el.find_element(:xpath, "./parent::label")
+          label = el.find_child_element(:xpath, "./parent::label")
         rescue
           id = el.attribute("id")
-          label = el.find_element(:xpath, "//label[@for='#{id}']")
+          label = el.find_child_element(:xpath, "//label[@for='#{id}']")
         end
         if label.text == val
           label.click

--- a/src/webdriver_pump/elements/select_list.cr
+++ b/src/webdriver_pump/elements/select_list.cr
@@ -1,13 +1,13 @@
 module WebdriverPump
   class SelectList < SimpleFormElement
     def value
-      @element.find_elements(:xpath, ".//option").each do |option|
+      @element.find_child_elements(:xpath, ".//option").each do |option|
         return option.text if option.selected?
       end
     end
 
     def value=(val)
-      @element.find_elements(:xpath, ".//option").each do |option|
+      @element.find_child_elements(:xpath, ".//option").each do |option|
         option.click if option.selected?
         if val.includes?(option.text)
           option.click

--- a/src/webdriver_pump/form_element.cr
+++ b/src/webdriver_pump/form_element.cr
@@ -1,6 +1,6 @@
 module WebdriverPump
   abstract class SimpleFormElement
-    def initialize(@element : Selenium::WebElement)
+    def initialize(@element : Selenium::Element)
     end
 
     abstract def value
@@ -8,7 +8,7 @@ module WebdriverPump
   end
 
   abstract class ComplexFormElement
-    def initialize(@elements : Array(Selenium::WebElement))
+    def initialize(@elements : Array(Selenium::Element))
     end
 
     abstract def value

--- a/src/webdriver_pump/locator.cr
+++ b/src/webdriver_pump/locator.cr
@@ -1,4 +1,4 @@
 module WebdriverPump
-  alias ElementLocator = Proc(Selenium::WebElement) | NamedTuple(id: String) | NamedTuple(xpath: String) | NamedTuple(name: String) | NamedTuple(class_name: String) | NamedTuple(css: String) | NamedTuple(tag_name: String) | NamedTuple(link_text: String) | NamedTuple(partial_link_text: String)
-  alias ElementsLocator = Proc(Array(Selenium::WebElement)) | NamedTuple(id: String) | NamedTuple(xpath: String) | NamedTuple(name: String) | NamedTuple(class_name: String) | NamedTuple(css: String) | NamedTuple(tag_name: String) | NamedTuple(link_text: String) | NamedTuple(partial_link_text: String)
+  alias ElementLocator = Proc(Selenium::Element) | NamedTuple(id: String) | NamedTuple(xpath: String) | NamedTuple(name: String) | NamedTuple(class_name: String) | NamedTuple(css: String) | NamedTuple(tag_name: String) | NamedTuple(link_text: String) | NamedTuple(partial_link_text: String)
+  alias ElementsLocator = Proc(Array(Selenium::Element)) | NamedTuple(id: String) | NamedTuple(xpath: String) | NamedTuple(name: String) | NamedTuple(class_name: String) | NamedTuple(css: String) | NamedTuple(tag_name: String) | NamedTuple(link_text: String) | NamedTuple(partial_link_text: String)
 end

--- a/src/webdriver_pump/page.cr
+++ b/src/webdriver_pump/page.cr
@@ -11,7 +11,7 @@ module WebdriverPump
 
     def initialize(@session : Selenium::Session)
       # HACK: Fake root is required to match expected variable type. Proper one is set in #open
-      @root = Selenium::WebElement.new(@session, JSON.parse(%({"ELEMENT": "body"})).as_h)
+      @root = @session.find_element(:xpath, "//body")
     end
 
     def open(*, params : NamedTuple? = nil, query : NamedTuple? = nil, &blk : self -> _)
@@ -23,7 +23,7 @@ module WebdriverPump
         query_string = query.map { |k, v| "#{URI.encode(k.to_s)}=#{URI.encode(v)}" }.join("&")
         processed_url = "#{processed_url}?#{query_string}"
       end
-      session.url = processed_url
+      session.navigate_to(processed_url)
       @root = @session.find_element(:xpath, "//body")
       use(&blk)
     end


### PR DESCRIPTION
Seems that `selenium-webdriver-crystal` is not maintained anymore, and not compatible with `crystal v1.0.0.`. This PR migrates to [selenium.cr](https://github.com/matthewmcgarvey/selenium.cr), that is kept up to date.